### PR TITLE
fix: load of latest DaCy model

### DIFF
--- a/textprivacy/textanonymization.py
+++ b/textprivacy/textanonymization.py
@@ -31,7 +31,7 @@ except RuntimeError:
 # Hack to make DaCy multiprocessable for both spawn and fork (SpaCy 3.0 issue with pickle)
 torch.set_num_threads(1)
 num_cpus: int = int(os.cpu_count())  # type: ignore
-ner_model = dacy.load("da_dacy_large_tft-0.0.0")
+ner_model = dacy.load("large")
 
 
 def worker(text: List[str]):  # type: ignore


### PR DESCRIPTION
Updated the **DaCy** model loading to use `large` instead of the specific version `da_dacy_large_tft-0.0.0` to ensure compatibility with the latest model. This prevents errors caused by deprecated model versions and simplifies future updates.

Not sure if the package is still actively maintained, but this just a simple quick fix :)